### PR TITLE
Add a check that body index is not nil

### DIFF
--- a/lib/rails_live_reload/middleware/base.rb
+++ b/lib/rails_live_reload/middleware/base.rb
@@ -32,6 +32,8 @@ module RailsLiveReload
 
       def make_new_response(body)
         index = body.rindex(/<\/body>/i) || body.rindex(/<\/html>/i)
+        return body if index.nil?
+
         body.insert(index, <<~HTML.html_safe)
           <script defer type="text/javascript" src="#{RailsLiveReload.config.url}/script"></script>
           <script id="rails-live-reload-options" type="application/json">


### PR DESCRIPTION
This PR fixes #20 by returning original response body in case it doesn't not contain `body` or `html` elements