### PR TITLE
Allow user to signal they're in server process via environment variable

### DIFF
--- a/lib/rails_live_reload/engine.rb
+++ b/lib/rails_live_reload/engine.rb
@@ -1,6 +1,6 @@
 module RailsLiveReload
   class Railtie < ::Rails::Engine
-    if RailsLiveReload.enabled? && defined?(::Rails::Server)
+    if RailsLiveReload.enabled? && (defined?(::Rails::Server) || ENV['SERVER_PROCESS'])
       initializer "rails_live_reload.middleware" do |app|
         if ::Rails::VERSION::MAJOR.to_i >= 5
           app.middleware.insert_after ActionDispatch::Executor, RailsLiveReload::Middleware::Base


### PR DESCRIPTION
RailsLiveReload currently relies on the `::Rails::Server` being available to run, I'm assuming this is just a proxy for understanding that you're in a server process and when Rails users start up their server with `rails s` this works great.  

However my team, and I would think many others may be calling `puma` or their other web server directly to start their Rails server.  `rails s` has a limited set of options, and it doesn't seem to even respect most of the options in the context of puma (port/bind options).  For that reason my team calls `bundle exec puma` directly and passes it different config files per environment.

All that being said this small PR gives users the option to tell `RailsLiveReload` through environment variables that it is indeed in a server process, and thus safe to start up.

This may also help solve: https://github.com/railsjazz/rails_live_reload/issues/30