### PR TITLE
Fix "config.enabled" not working

### DIFF
--- a/lib/rails_live_reload/engine.rb
+++ b/lib/rails_live_reload/engine.rb
@@ -1,7 +1,11 @@
 module RailsLiveReload
   class Railtie < ::Rails::Engine
-    if RailsLiveReload.enabled? && (defined?(::Rails::Server) || ENV['SERVER_PROCESS'])
-      initializer "rails_live_reload.middleware" do |app|
+    def enabled?
+      RailsLiveReload.enabled? && (defined?(::Rails::Server) || ENV['SERVER_PROCESS'])
+    end
+
+    initializer "rails_live_reload.middleware" do |app|
+      if enabled?
         if ::Rails::VERSION::MAJOR.to_i >= 5
           app.middleware.insert_after ActionDispatch::Executor, RailsLiveReload::Middleware::Base
         else
@@ -12,25 +16,33 @@ module RailsLiveReload
           end
         end
       end
+    end
 
-      initializer "rails_live_reload.watcher" do
+    initializer "rails_live_reload.watcher" do
+      if enabled?
         RailsLiveReload::Watcher.init
       end
+    end
 
-      initializer "rails_live_reload.configure_metrics", after: :initialize_logger do
+    initializer "rails_live_reload.configure_metrics", after: :initialize_logger do
+      if enabled?
         ActiveSupport::Notifications.subscribe(
           /\.action_view/,
           RailsLiveReload::Instrument::MetricsCollector.new
         )
       end
+    end
 
-      initializer "rails_live_reload.reset_current_request", after: :initialize_logger do |app|
+    initializer "rails_live_reload.reset_current_request", after: :initialize_logger do |app|
+      if enabled?
         app.executor.to_run      { CurrentRequest.cleanup }
         app.executor.to_complete { CurrentRequest.cleanup }
       end
+    end
 
-      initializer "rails_live_reload.routes" do
-        config.after_initialize do |app|
+    initializer "rails_live_reload.routes" do
+      config.after_initialize do |app|
+        if enabled?
           app.routes.prepend do
             mount RailsLiveReload.server => RailsLiveReload.config.url, internal: true
           end


### PR DESCRIPTION
This is a proposed fix for #26.

The `RailsLiveReload.enabled?` check is currently performed immediately when the Railtie class is interpreted, returning `true` since it's the default value. However, due to the Rails application lifecycle, the state of `RailsLiveReload.enabled?` will change by the time the initializers are run and it will return the value specified in the rails app initializer.

I tried moving the  `RailsLiveReload.enabled?` check into each initializer block and it seems to be fixing the issue.