### PR TITLE
Support for nonce CSP

### DIFF
--- a/lib/rails_live_reload/middleware/base.rb
+++ b/lib/rails_live_reload/middleware/base.rb
@@ -15,11 +15,11 @@ module RailsLiveReload
             @app.call(env)
           end
         else
-          request = Rack::Request.new(env)
+          request = ActionDispatch::Request.new(env)
           status, headers, body = @app.call(env)
 
           if html?(headers) && (status == 500 || (status.to_s =~ /20./ && request.get?))
-            return inject_rails_live_reload(status, headers, body)
+            return inject_rails_live_reload(request, status, headers, body)
           end
 
           [status, headers, body]
@@ -28,25 +28,26 @@ module RailsLiveReload
 
       private
 
-      def inject_rails_live_reload(status, headers, body)
+      def inject_rails_live_reload(request, status, headers, body)
         response = Rack::Response.new([], status, headers)
-
+        
+        nonce = request&.content_security_policy_nonce
         if String === body
-          response.write make_new_response(body)
+          response.write make_new_response(body, nonce)
         else
-          body.each { |fragment| response.write make_new_response(fragment) }
+          body.each { |fragment| response.write make_new_response(fragment, nonce) }
         end
         body.close if body.respond_to?(:close)
         response.finish
       end
 
-      def make_new_response(body)
+      def make_new_response(body, nonce)
         index = body.rindex(/<\/body>/i) || body.rindex(/<\/html>/i)
         return body if index.nil?
 
         body.insert(index, <<~HTML.html_safe)
           <script defer type="text/javascript" src="#{RailsLiveReload.config.url}/script"></script>
-          <script id="rails-live-reload-options" type="application/json">
+          <script id="rails-live-reload-options" type="application/json" nonce="#{nonce}">
             #{{
               files: CurrentRequest.current.data.to_a,
               time: Time.now.to_i,


### PR DESCRIPTION
Currently `rails_live_reload` is not usable with decent CSP directive (no `unsafe-inline`) and the content is blocked
This patch use the native rails CSP nonce to whitelist the injected script

See
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce https://api.rubyonrails.org/classes/ActionDispatch/ContentSecurityPolicy/Request.html#method-i-content_security_policy_nonce_generator