### PR TITLE
Fix headers check for HTML content-type

### DIFF
--- a/lib/rails_live_reload/middleware/base.rb
+++ b/lib/rails_live_reload/middleware/base.rb
@@ -57,7 +57,7 @@ module RailsLiveReload
       end
 
       def html?(headers)
-        headers["Content-Type"].to_s.include?("text/html")
+        headers["content-type"].to_s.include?("text/html")
       end
     end
   end


### PR DESCRIPTION
For normal requests, headers are using the `Rack::Headers` where keys are case-insensitive.

In `ActionDispatch::ShowExceptions`, Rails uses a Hash instead which is case-sensitive. It uses the `Rack::CONTENT_TYPE` constant that is a down-case version of the header key.

In this commit, I changed the "Content-Type" key to "content-type" so that live reloading still works in the Rails error page.