### PR TITLE
Add an option to ignore unnecessary directories such as `node_modules/`

### DIFF
--- a/lib/generators/templates/rails_live_reload.rb
+++ b/lib/generators/templates/rails_live_reload.rb
@@ -11,5 +11,8 @@ RailsLiveReload.configure do |config|
   # config.watch %r{app/helpers/.+\.rb}, reload: :always
   # config.watch %r{config/locales/.+\.yml}, reload: :always
 
+  # Ignored folders & files
+  # config.ignore %r{node_modules/}
+
   # config.enabled = Rails.env.development?
 end if defined?(RailsLiveReload)

--- a/lib/rails_live_reload/config.rb
+++ b/lib/rails_live_reload/config.rb
@@ -12,13 +12,17 @@ module RailsLiveReload
       config.patterns
     end
 
+    def ignore_patterns
+      config.ignore_patterns
+    end
+
     def enabled?
       config.enabled
     end
   end
 
   class Config
-    attr_reader :patterns
+    attr_reader :patterns, :ignore_patterns
     attr_accessor :url, :watcher, :files, :enabled
 
     def initialize
@@ -33,6 +37,8 @@ module RailsLiveReload
         %r{(app|vendor)/(assets|javascript)/\w+/(.+\.(css|js|html|png|jpg|ts|jsx)).*} => :always
       }
       @default_patterns_changed = false
+
+      @ignore_patterns = []
     end
 
     def root_path
@@ -46,6 +52,10 @@ module RailsLiveReload
       end
 
       patterns[pattern] = reload
+    end
+
+    def ignore(pattern)
+      @ignore_patterns << pattern
     end
 
     def socket_path

--- a/lib/rails_live_reload/watcher.rb
+++ b/lib/rails_live_reload/watcher.rb
@@ -27,7 +27,7 @@ module RailsLiveReload
 
     def start_listener
       Thread.new do
-        listener = Listen.to(root) do |modified, added, removed|
+        listener = Listen.to(root, ignore: RailsLiveReload.ignore_patterns) do |modified, added, removed|
           all = modified + added + removed
           all.each do |file|
             files[file] = File.mtime(file).to_i rescue nil


### PR DESCRIPTION
This Pull Request introduces an `ignore` option to the configuration settings.

### Motivation / Background

In my hobby application, I encountered an error caused by the `rails_live_reload` gem monitoring JavaScript files under the `node_modules/` directory.  
After investigating the issue, I found that properly configuring the `ignore` option in the `Listen.to` method, which is used internally by this gem, resolves the problem.  
To help other developers address similar issues independently, I added the `ignore` option to the gem's configuration settings.

Related issue: #38 