### PR TITLE
Ensure reload works even when the socket directory does not exist

### DIFF
--- a/lib/rails_live_reload/watcher.rb
+++ b/lib/rails_live_reload/watcher.rb
@@ -1,3 +1,5 @@
+require "fileutils"
+
 module RailsLiveReload
   class Watcher
     attr_reader :files, :sockets
@@ -21,6 +23,7 @@ module RailsLiveReload
       end
 
       build_tree
+      create_socket_directory
       start_socket
       start_listener
     end
@@ -53,6 +56,10 @@ module RailsLiveReload
       @sockets.each do |socket, _|
         socket.puts data
       end
+    end
+
+    def create_socket_directory
+      FileUtils.mkdir_p File.dirname(RailsLiveReload.config.socket_path)
     end
 
     def start_socket


### PR DESCRIPTION
I use this gem with `puma-dev` by adding `export SERVER_PROCESS=1` to `.pumaenv` (#31) .

In this setup, the `tmp/sockets` directory is not created, which causes the gem to not work properly.
![console](https://github.com/user-attachments/assets/4751fab8-cdc2-49cf-b793-c1d5b0f2a4a8)
(Note: When running `rails s`, the directory is automatically created.)

I have modified the code to automatically create the socket directory if it does not exist.